### PR TITLE
feat: add whitelist middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,90 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-consensus"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cc7579e4fb5558af44810f542c90d1145dba8b92c08211c215196160c48d2ea"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "c-kzg",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bdbc8d98cc36ebe17bb5b42d0873137bc76628a4ee0f7e7acad5b8fc59d3597"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "c-kzg",
+ "once_cell",
+ "serde",
+ "sha2",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f783611babedbbe90db3478c120fb5f5daacceffc210b39adc0af4fe0da70bad"
+dependencies = [
+ "alloy-rlp",
+ "bytes 1.6.0",
+ "cfg-if 1.0.0",
+ "const-hex",
+ "derive_more",
+ "hex-literal",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "proptest",
+ "rand 0.8.5",
+ "ruint",
+ "serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b155716bab55763c95ba212806cf43d05bcc70e5f35b02bad20cf5ec7fe11fed"
+dependencies = [
+ "alloy-rlp-derive",
+ "arrayvec",
+ "bytes 1.6.0",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8037e03c7f462a063f28daec9fda285a9a89da003c552f8637a80b9c8fd96241"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c224916316519558d8c2b6a60dc7626688c08f1b8951774702562dbcb8666ee"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +215,130 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
 
 [[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.0",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,7 +390,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -193,7 +401,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -201,6 +409,17 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "auto_impl"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
+]
 
 [[package]]
 name = "autocfg"
@@ -269,6 +488,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +504,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "beef"
@@ -299,6 +530,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +555,18 @@ name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "blake2"
@@ -350,6 +608,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "blst"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62dc83a094a71d43eeadd254b1ec2d24cb6a0bb6cadce00df51f0db594711a32"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
 name = "brotli"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +657,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+
+[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,6 +695,23 @@ name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "c-kzg"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf100c4cea8f207e883ff91ca886d621d8a166cb04971dfaa9bb8fd99ed95df"
+dependencies = [
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "serde",
+]
 
 [[package]]
 name = "card-validate"
@@ -546,7 +839,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -630,6 +923,31 @@ dependencies = [
  "tracing-core",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "const-hex"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8a24a26d37e1ffd45343323dc9fe6654ceea44c12f2fcb3d7ac29e610bc6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "hex",
+ "proptest",
+ "serde",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
@@ -753,6 +1071,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array 0.14.7",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +1115,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.0",
+ "syn 2.0.61",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,13 +1159,37 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -809,6 +1197,25 @@ name = "either"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array 0.14.7",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -836,7 +1243,7 @@ checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -900,6 +1307,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes 1.6.0",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "findshlibs"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +1337,18 @@ dependencies = [
  "lazy_static",
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand 0.8.5",
+ "rustc-hex",
+ "static_assertions",
 ]
 
 [[package]]
@@ -951,6 +1391,12 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1009,7 +1455,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1080,7 +1526,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1100,6 +1546,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1129,6 +1576,12 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
@@ -1203,6 +1656,17 @@ dependencies = [
  "quanta 0.11.1",
  "rand 0.8.5",
  "smallvec",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1295,6 +1759,30 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "http"
@@ -1512,6 +2000,26 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1866,7 +2374,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1936,6 +2444,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+]
+
+[[package]]
+name = "keccak-asm"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47a3633291834c4fbebf8673acbc1b04ec9d151418ff9b8e26dcd79129928758"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,6 +2493,12 @@ name = "libc"
 version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linked-hash-map"
@@ -2140,7 +2677,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.2",
  "quanta 0.12.3",
- "rustc_version",
+ "rustc_version 0.4.0",
  "smallvec",
  "tagptr",
  "thiserror",
@@ -2238,6 +2775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2410,6 +2948,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parity-scale-codec"
+version = "3.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "parity-ws"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,6 +3058,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pest"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
 name = "phonenumber"
 version = "0.3.4+8.13.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2531,7 +3106,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2545,6 +3120,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2609,6 +3194,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2641,6 +3237,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.5.0",
+ "lazy_static",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "regex-syntax 0.8.3",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2660,7 +3276,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2704,6 +3320,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quick-xml"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2729,6 +3351,12 @@ checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -2799,6 +3427,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2950,6 +3587,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2974,6 +3621,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes 1.6.0",
+ "rustc-hex",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2991,6 +3648,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
+name = "ruint"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3cc4c2511671f327125da14133d0c5c5d137f006a1017a16f557bc85b16286"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "bytes 1.6.0",
+ "fastrlp",
+ "num-bigint",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types",
+ "proptest",
+ "rand 0.8.5",
+ "rlp",
+ "ruint-macro",
+ "serde",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3003,12 +3690,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.23",
 ]
 
 [[package]]
@@ -3113,6 +3815,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092474d1a01ea8278f69e6a358998405fae5b8b963ddaeb2b0b04a128bf1dfb0"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3143,6 +3857,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array 0.14.7",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3168,9 +3896,27 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "send_wrapper"
@@ -3195,7 +3941,7 @@ checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -3258,6 +4004,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3-asm"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b57fd861253bff08bb1919e995f90ba8f4889de2726091c8876f3a4e823b40"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3273,6 +4040,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3326,6 +4103,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3368,7 +4155,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -3394,6 +4181,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 name = "subway"
 version = "0.1.0"
 dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
  "anyhow",
  "async-trait",
  "blake2",
@@ -3459,6 +4249,17 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
@@ -3502,6 +4303,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3530,7 +4337,7 @@ checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -3563,6 +4370,15 @@ dependencies = [
  "log",
  "ordered-float 2.10.1",
  "threadpool",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -3628,7 +4444,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -3810,7 +4626,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -3882,6 +4698,30 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
@@ -3976,6 +4816,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4027,7 +4876,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.61",
  "wasm-bindgen-shared",
 ]
 
@@ -4061,7 +4910,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.61",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4312,6 +5161,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4328,7 +5186,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -4336,6 +5194,20 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,11 @@ garde = { version = "0.18", features = ["full"] }
 jsonrpsee = { version = "0.23", features = ["full"] }
 governor = { path = "./vendor/governor/governor" }
 
+# Alloy
+alloy-eips = { version = "0.1.1" }
+alloy-consensus = { version = "0.1.1", features = ["k256", "serde"] }
+alloy-primitives = { version = "0.7.6", features = ["serde"] }
+
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["async_tokio", "html_reports"] }
 pprof = { version = "0.13.0", features = ["flamegraph", "criterion"] }

--- a/configs/demo_config.yml
+++ b/configs/demo_config.yml
@@ -18,9 +18,20 @@ extensions:
     cors: all
   whitelist:
     eth_call_whitelist:
-      - to: 0x0000000000000000000000000000000000000000
+      # allow 0x01 to call 0x02
+      - from: 0000000000000000000000000000000000000001
+        to: 0000000000000000000000000000000000000002
+      # allow anyone to call 0x01
+      - to: 0000000000000000000000000000000000000000
+      # allow 0x02 to create contract
+      - from: 0000000000000000000000000000000000000002
+        to: create
     raw_tx_whitelist:
-      - from: 0x0000000000000000000000000000000000000000
+      # allow 0x01 to call or create in raw tx.
+      - from: 0000000000000000000000000000000000000001
+    tx_whitelist:
+      # allow 0x01 to call or create in tx.
+      - from: 0000000000000000000000000000000000000001
 middlewares:
   methods:
     - whitelist

--- a/configs/demo_config.yml
+++ b/configs/demo_config.yml
@@ -26,9 +26,6 @@ extensions:
       # allow 0x02 to create contract
       - from: 0000000000000000000000000000000000000002
         to: create
-    raw_tx_whitelist:
-      # allow 0x01 to call or create in raw tx.
-      - from: 0000000000000000000000000000000000000001
     tx_whitelist:
       # allow 0x01 to call or create in tx.
       - from: 0000000000000000000000000000000000000001

--- a/configs/demo_config.yml
+++ b/configs/demo_config.yml
@@ -1,0 +1,34 @@
+extensions:
+  client:
+    endpoints:
+      - wss://cyber-testnet.alt.technology/ws
+  event_bus:
+  eth_api:
+    stale_timeout_seconds: 180 # rotate endpoint if no new blocks for 3 minutes
+  telemetry:
+    provider: none
+  cache:
+    default_ttl_seconds: 60
+    default_size: 500
+  server:
+    port: 8545
+    listen_address: '0.0.0.0'
+    max_connections: 2000
+    max_batch_size: 10
+    cors: all
+  whitelist:
+    eth_call_whitelist:
+      - to: 0x0000000000000000000000000000000000000000
+    raw_tx_whitelist:
+      - from: 0x0000000000000000000000000000000000000000
+middlewares:
+  methods:
+    - whitelist
+    - response
+    - block_tag
+    - cache
+    - upstream
+  subscriptions:
+    - upstream
+
+rpcs: ethereum

--- a/rpc_configs/ethereum.yml
+++ b/rpc_configs/ethereum.yml
@@ -123,7 +123,7 @@ methods:
       - name: blockCount
         ty: Bytes
       - name: newestBlock
-        ty: boolean
+        ty: Boolean
       - name: rewardPercentiles
         ty: Bytes
 

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -18,6 +18,7 @@ pub mod rate_limit;
 pub mod server;
 pub mod telemetry;
 pub mod validator;
+pub mod whitelist;
 
 #[async_trait]
 pub trait Extension: Sized {
@@ -145,4 +146,5 @@ define_all_extensions! {
     rate_limit: rate_limit::RateLimitBuilder,
     prometheus: prometheus::Prometheus,
     validator: validator::Validator,
+    whitelist: whitelist::Whitelist,
 }

--- a/src/extensions/whitelist/mod.rs
+++ b/src/extensions/whitelist/mod.rs
@@ -1,0 +1,86 @@
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use super::{Extension, ExtensionRegistry};
+
+pub const SEND_RAW: &'static str = "eth_sendRawTransaction";
+pub const ETH_CALL: &'static str = "eth_call";
+
+pub struct Whitelist {
+    pub config: WhitelistConfig,
+}
+
+/// The address whitelist for `eth_call/eth_sendRawTransaction` rpc.
+#[derive(Deserialize, Debug, Clone)]
+pub struct WhitelistConfig {
+    pub eth_call_whitelist: Vec<WhiteAddress>,
+    pub raw_tx_whitelist: Vec<WhiteAddress>,
+}
+
+impl WhitelistConfig {
+    /// Normalize the config name cases.
+    pub fn normalize(&mut self) {
+        for addr in self.eth_call_whitelist.iter_mut() {
+            addr.normalize();
+        }
+
+        for addr in self.raw_tx_whitelist.iter_mut() {
+            addr.normalize();
+        }
+    }
+}
+
+/// When an address is None, it means it will satisfy any address.
+#[derive(Deserialize, Debug, Clone)]
+pub struct WhiteAddress {
+    /// Should check the address if Some.
+    pub from: Option<String>,
+    /// Should check the address if Some.
+    pub to: Option<String>,
+}
+
+impl WhiteAddress {
+    /// Normalize the address.
+    pub fn normalize(&mut self) {
+        if let Some(addr) = self.from.as_mut() {
+            *addr = addr.to_lowercase();
+        }
+        if let Some(addr) = self.to.as_mut() {
+            *addr = addr.to_lowercase();
+        }
+    }
+
+    pub fn satisfy_from_address(&self, from: impl AsRef<str>) -> bool {
+        let from = from.as_ref();
+
+        self.from.as_deref() == None || self.from.as_deref() == Some(from)
+    }
+
+    pub fn satisfy_to_address(&self, to: impl AsRef<str>) -> bool {
+        let to = to.as_ref();
+
+        self.to.as_deref() == None || self.to.as_deref() == Some(to)
+    }
+
+    /// Check if this is a white address.
+    pub fn satisfy(&self, from: impl AsRef<str>, to: impl AsRef<str>) -> bool {
+        self.satisfy_from_address(from) && self.satisfy_to_address(to)
+    }
+}
+
+impl Whitelist {
+    pub fn new(config: WhitelistConfig) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait]
+impl Extension for Whitelist {
+    type Config = WhitelistConfig;
+
+    async fn from_config(config: &Self::Config, _registry: &ExtensionRegistry) -> Result<Self, anyhow::Error> {
+        let mut config = config.clone();
+        config.normalize();
+        Ok(Self::new(config))
+    }
+}

--- a/src/extensions/whitelist/mod.rs
+++ b/src/extensions/whitelist/mod.rs
@@ -22,8 +22,6 @@ pub struct WhitelistConfig {
     #[serde(default)]
     pub eth_call_whitelist: Vec<WhiteAddress>,
     #[serde(default)]
-    pub raw_tx_whitelist: Vec<WhiteAddress>,
-    #[serde(default)]
     pub tx_whitelist: Vec<WhiteAddress>,
 }
 

--- a/src/extensions/whitelist/mod.rs
+++ b/src/extensions/whitelist/mod.rs
@@ -19,9 +19,9 @@ pub struct Whitelist {
 /// The address whitelist for `eth_call/eth_sendRawTransaction` rpc.
 #[derive(Deserialize, Debug, Clone)]
 pub struct WhitelistConfig {
-    #[serde(default)]
+    #[serde(default, alias = "eth_call")]
     pub eth_call_whitelist: Vec<WhiteAddress>,
-    #[serde(default)]
+    #[serde(default, alias = "tx")]
     pub tx_whitelist: Vec<WhiteAddress>,
 }
 

--- a/src/extensions/whitelist/mod.rs
+++ b/src/extensions/whitelist/mod.rs
@@ -1,8 +1,7 @@
+use crate::utils::ToAddress;
 use alloy_primitives::Address;
 use async_trait::async_trait;
-use serde::{Deserialize, Deserializer};
-use std::fmt::Display;
-use crate::utils::ToAddress;
+use serde::Deserialize;
 
 use super::{Extension, ExtensionRegistry};
 
@@ -28,25 +27,6 @@ pub struct WhitelistConfig {
     pub tx_whitelist: Vec<WhiteAddress>,
 }
 
-impl WhitelistConfig {
-    /// Normalize the config name cases.
-    pub fn normalize(&mut self) -> anyhow::Result<()> {
-        for addr in self.eth_call_whitelist.iter_mut() {
-            addr.normalize()?;
-        }
-
-        for addr in self.raw_tx_whitelist.iter_mut() {
-            addr.normalize()?;
-        }
-
-        for addr in self.tx_whitelist.iter_mut() {
-            addr.normalize()?;
-        }
-
-        Ok(())
-    }
-}
-
 /// When an address is None, it means it will satisfy any address.
 #[derive(Deserialize, Debug, Clone)]
 pub struct WhiteAddress {
@@ -68,7 +48,6 @@ impl Extension for Whitelist {
 
     async fn from_config(config: &Self::Config, _registry: &ExtensionRegistry) -> Result<Self, anyhow::Error> {
         let mut config = config.clone();
-        config.normalize()?;
         Ok(Self::new(config))
     }
 }

--- a/src/extensions/whitelist/mod.rs
+++ b/src/extensions/whitelist/mod.rs
@@ -47,7 +47,6 @@ impl Extension for Whitelist {
     type Config = WhitelistConfig;
 
     async fn from_config(config: &Self::Config, _registry: &ExtensionRegistry) -> Result<Self, anyhow::Error> {
-        let mut config = config.clone();
-        Ok(Self::new(config))
+        Ok(Self::new(config.clone()))
     }
 }

--- a/src/middlewares/factory.rs
+++ b/src/middlewares/factory.rs
@@ -24,6 +24,8 @@ pub async fn create_method_middleware(
     use super::methods::*;
 
     match name {
+        "whitelist" => whitelist::WhitelistMiddleware::build(method, extensions).await,
+
         "response" => response::ResponseMiddleware::build(method, extensions).await,
         "upstream" => upstream::UpstreamMiddleware::build(method, extensions).await,
         "cache" => cache::CacheMiddleware::build(method, extensions).await,

--- a/src/middlewares/methods/mod.rs
+++ b/src/middlewares/methods/mod.rs
@@ -5,6 +5,7 @@ pub mod inject_params;
 pub mod response;
 pub mod upstream;
 pub mod validate;
+pub mod whitelist;
 
 #[cfg(test)]
 pub mod testing;

--- a/src/middlewares/methods/whitelist.rs
+++ b/src/middlewares/methods/whitelist.rs
@@ -4,7 +4,11 @@ use jsonrpsee::types::ErrorObjectOwned;
 use opentelemetry::trace::FutureExt;
 use serde_json::value::RawValue;
 
-use crate::extensions::whitelist::{WhiteAddress, Whitelist, ETH_CALL, SEND_RAW};
+use alloy_consensus::{Transaction, TxEip4844Variant, TxEnvelope};
+use alloy_eips::eip2718::Decodable2718;
+use alloy_primitives::{Address, TxKind};
+
+use crate::extensions::whitelist::{WhiteAddress, Whitelist, ETH_CALL, SEND_RAW_TX, SEND_TX, ToAddress};
 use crate::{
     middlewares::{CallRequest, CallResult, Middleware, MiddlewareBuilder, NextFn, RpcMethod, TRACER},
     utils::{TypeRegistry, TypeRegistryRef},
@@ -16,6 +20,12 @@ pub const ADDRESS_IS_BANNED: i32 = -33000;
 /// The address must be parsed from the rpc parameters.
 pub const UNKNOWN_ADDRESS: i32 = -33001;
 
+///The transaction could not be decoded.
+pub const ILLEGAL_TX: i32 = -33002;
+
+/// The transaction signature is invalid.
+pub const ILLEGAL_TX_SIGNATURE: i32 = -33003;
+
 /// This whitelist middleware should be used at the top level whenever possible.
 pub struct WhitelistMiddleware {
     rpc_type: RpcType,
@@ -25,16 +35,17 @@ pub struct WhitelistMiddleware {
 #[derive(Debug, Eq, PartialEq)]
 enum RpcType {
     EthCall,
-    SendRaw,
+    SendRawTX,
+    SendTX,
 }
 
 impl WhitelistMiddleware {
     /// Return true if it's in whitelist.
-    pub fn satisfy(&self, from: String, to: String) -> bool {
+    pub fn satisfy(&self, from: &Address, to: &ToAddress) -> bool {
         let mut allowed = false;
         for address in &self.addresses {
             // if satisfy address from/to
-            if address.satisfy(from.as_str(), to.as_str()) {
+            if address.satisfy(from, to) {
                 allowed = true;
                 break;
             }
@@ -56,25 +67,29 @@ impl MiddlewareBuilder<RpcMethod, CallRequest, CallResult> for WhitelistMiddlewa
             .get::<Whitelist>()
             .expect("WhitelistConfig extension not found");
 
-        if &method.method == SEND_RAW {
-            Some(Box::new(Self {
-                rpc_type: RpcType::SendRaw,
-                addresses: whitelist.config.raw_tx_whitelist.clone(),
-            }))
-        } else if &method.method == ETH_CALL {
-            Some(Box::new(Self {
+        match method.method.as_str() {
+            ETH_CALL => Some(Box::new(Self {
                 rpc_type: RpcType::EthCall,
                 addresses: whitelist.config.eth_call_whitelist.clone(),
-            }))
-        } else {
-            // other rpc types will skip this middleware.
-            None
+            })),
+            SEND_TX => Some(Box::new(Self {
+                rpc_type: RpcType::SendRawTX,
+                addresses: whitelist.config.raw_tx_whitelist.clone(),
+            })),
+            SEND_RAW_TX => Some(Box::new(Self {
+                rpc_type: RpcType::SendTX,
+                addresses: whitelist.config.tx_whitelist.clone(),
+            })),
+            _ => {
+                // other rpc types will skip this middleware.
+                None
+            }
         }
     }
 }
 
-/// Extract the address from parameters and convert it into lowercase.
-pub fn extract_address_from_to(params: &[JsonValue]) -> Result<(String, String), ErrorObjectOwned> {
+/// Extract the address from `eth_call`/`eth_sendTranslation` parameters and convert it into lowercase.
+pub fn extract_address_from_to(params: &[JsonValue]) -> Result<(Address, TxKind), ErrorObjectOwned> {
     let p1 = params.get(0).ok_or_else(|| {
         ErrorObjectOwned::borrowed(
             UNKNOWN_ADDRESS,
@@ -83,28 +98,21 @@ pub fn extract_address_from_to(params: &[JsonValue]) -> Result<(String, String),
         )
     })?;
 
+    // `from` must exist.
     let from = p1.get("from").ok_or_else(|| {
         ErrorObjectOwned::borrowed(UNKNOWN_ADDRESS, "Could not get the `from` from rpc parameter", None)
     })?;
-    let from: String = serde_json::from_value(from.clone()).map_err(|_err| {
+    let from: Address = serde_json::from_value(from.clone()).map_err(|_err| {
         ErrorObjectOwned::borrowed(UNKNOWN_ADDRESS, "Could not parse `from` from rpc parameter", None)
     })?;
 
     let to = p1.get("to").ok_or_else(|| {
         ErrorObjectOwned::borrowed(UNKNOWN_ADDRESS, "Could not get the `to` from rpc parameter", None)
     })?;
-    let to: String = serde_json::from_value(to.clone())
+    let to: TxKind = serde_json::from_value(to.clone())
         .map_err(|_err| ErrorObjectOwned::borrowed(UNKNOWN_ADDRESS, "Could not parse `to` from rpc parameter", None))?;
 
-    Ok((from.to_lowercase(), to.to_lowercase()))
-}
-
-pub fn banned_address_call_result(data: Option<&'static RawValue>) -> CallResult {
-    Err(ErrorObjectOwned::borrowed(
-        ADDRESS_IS_BANNED,
-        "The address related to the rpc is banned",
-        data,
-    ))
+    Ok((from, to))
 }
 
 #[async_trait]
@@ -116,14 +124,38 @@ impl Middleware<CallRequest, CallResult> for WhitelistMiddleware {
         next: NextFn<CallRequest, CallResult>,
     ) -> CallResult {
         async move {
+            // Not exist whitelist so return directly.
+            if self.addresses.is_empty() {
+                return next(request, context).await;
+            }
+
             match self.rpc_type {
-                RpcType::EthCall => {
+                RpcType::EthCall | RpcType::SendTX => {
                     let (from, to) = extract_address_from_to(&request.params)?;
-                    if !self.satisfy(from, to) {
+                    let to = to.into();
+                    if !self.satisfy(&from, &to) {
                         return banned_address_call_result(None);
                     }
                 }
-                RpcType::SendRaw => {
+                RpcType::SendRawTX => {
+                    let p1 = request.params.get(0).ok_or_else(|| {
+                        ErrorObjectOwned::borrowed(
+                            UNKNOWN_ADDRESS,
+                            "Could not get the first param from rpc parameter",
+                            None,
+                        )
+                    })?;
+                    let rlp_hex: String = serde_json::from_value(p1.clone()).map_err(|_err| {
+                        ErrorObjectOwned::borrowed(ILLEGAL_TX, "Could not get the first param from rpc parameter", None)
+                    })?;
+                    let tx: TxEnvelope = TxEnvelope::decode_2718(&mut rlp_hex.as_bytes())
+                        .map_err(|_err| ErrorObjectOwned::borrowed(ILLEGAL_TX, "Could not decode the raw txn", None))?;
+                    let from = extract_signer_from_tx_envelop(&tx)?;
+                    let to = extract_to_address_from_tx_envelop(&tx);
+                    let to = to.into();
+                    if !self.satisfy(&from, &to) {
+                        return banned_address_call_result(None);
+                    }
                     // TODO:
                 }
             }
@@ -133,4 +165,46 @@ impl Middleware<CallRequest, CallResult> for WhitelistMiddleware {
         .with_context(TRACER.context("whitelist"))
         .await
     }
+}
+
+#[inline]
+fn extract_signer_from_tx_envelop(tx: &TxEnvelope) -> Result<Address, ErrorObjectOwned> {
+    let signer = match tx {
+        TxEnvelope::Legacy(tx) => tx.recover_signer(),
+        TxEnvelope::Eip2930(tx) => tx.recover_signer(),
+        TxEnvelope::Eip1559(tx) => tx.recover_signer(),
+        TxEnvelope::Eip4844(tx) => tx.recover_signer(),
+        _ => {
+            unreachable!()
+        }
+    }
+    .map_err(|_err| ErrorObjectOwned::owned(ILLEGAL_TX_SIGNATURE, "Could not recover signer from tx", Some(tx)))?;
+
+    Ok(signer)
+}
+
+#[inline]
+fn extract_to_address_from_tx_envelop(tx: &TxEnvelope) -> TxKind {
+    let to = match tx {
+        TxEnvelope::Legacy(tx) => tx.tx().to,
+        TxEnvelope::Eip1559(tx) => tx.tx().to,
+        TxEnvelope::Eip2930(tx) => tx.tx().to,
+        TxEnvelope::Eip4844(tx) => match tx.tx() {
+            TxEip4844Variant::TxEip4844(tx) => tx.to(),
+            TxEip4844Variant::TxEip4844WithSidecar(tx) => tx.to(),
+        },
+        _ => {
+            unreachable!()
+        }
+    };
+
+    to
+}
+
+pub fn banned_address_call_result(data: Option<&'static RawValue>) -> CallResult {
+    Err(ErrorObjectOwned::borrowed(
+        ADDRESS_IS_BANNED,
+        "The address related to the rpc is banned",
+        data,
+    ))
 }

--- a/src/middlewares/methods/whitelist.rs
+++ b/src/middlewares/methods/whitelist.rs
@@ -1,0 +1,136 @@
+use async_trait::async_trait;
+use jsonrpsee::core::JsonValue;
+use jsonrpsee::types::ErrorObjectOwned;
+use opentelemetry::trace::FutureExt;
+use serde_json::value::RawValue;
+
+use crate::extensions::whitelist::{WhiteAddress, Whitelist, ETH_CALL, SEND_RAW};
+use crate::{
+    middlewares::{CallRequest, CallResult, Middleware, MiddlewareBuilder, NextFn, RpcMethod, TRACER},
+    utils::{TypeRegistry, TypeRegistryRef},
+};
+
+/// The related address is banned.
+pub const ADDRESS_IS_BANNED: i32 = -33000;
+
+/// The address must be parsed from the rpc parameters.
+pub const UNKNOWN_ADDRESS: i32 = -33001;
+
+/// This whitelist middleware should be used at the top level whenever possible.
+pub struct WhitelistMiddleware {
+    rpc_type: RpcType,
+    addresses: Vec<WhiteAddress>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum RpcType {
+    EthCall,
+    SendRaw,
+}
+
+impl WhitelistMiddleware {
+    /// Return true if it's in whitelist.
+    pub fn satisfy(&self, from: String, to: String) -> bool {
+        let mut allowed = false;
+        for address in &self.addresses {
+            // if satisfy address from/to
+            if address.satisfy(from.as_str(), to.as_str()) {
+                allowed = true;
+                break;
+            }
+        }
+
+        allowed
+    }
+}
+
+#[async_trait]
+impl MiddlewareBuilder<RpcMethod, CallRequest, CallResult> for WhitelistMiddleware {
+    async fn build(
+        method: &RpcMethod,
+        extensions: &TypeRegistryRef,
+    ) -> Option<Box<dyn Middleware<CallRequest, CallResult>>> {
+        let whitelist = extensions
+            .read()
+            .await
+            .get::<Whitelist>()
+            .expect("WhitelistConfig extension not found");
+
+        if &method.method == SEND_RAW {
+            Some(Box::new(Self {
+                rpc_type: RpcType::SendRaw,
+                addresses: whitelist.config.raw_tx_whitelist.clone(),
+            }))
+        } else if &method.method == ETH_CALL {
+            Some(Box::new(Self {
+                rpc_type: RpcType::EthCall,
+                addresses: whitelist.config.eth_call_whitelist.clone(),
+            }))
+        } else {
+            // other rpc types will skip this middleware.
+            None
+        }
+    }
+}
+
+/// Extract the address from parameters and convert it into lowercase.
+pub fn extract_address_from_to(params: &[JsonValue]) -> Result<(String, String), ErrorObjectOwned> {
+    let p1 = params.get(0).ok_or_else(|| {
+        ErrorObjectOwned::borrowed(
+            UNKNOWN_ADDRESS,
+            "Could not get the first param from rpc parameter",
+            None,
+        )
+    })?;
+
+    let from = p1.get("from").ok_or_else(|| {
+        ErrorObjectOwned::borrowed(UNKNOWN_ADDRESS, "Could not get the `from` from rpc parameter", None)
+    })?;
+    let from: String = serde_json::from_value(from.clone()).map_err(|_err| {
+        ErrorObjectOwned::borrowed(UNKNOWN_ADDRESS, "Could not parse `from` from rpc parameter", None)
+    })?;
+
+    let to = p1.get("to").ok_or_else(|| {
+        ErrorObjectOwned::borrowed(UNKNOWN_ADDRESS, "Could not get the `to` from rpc parameter", None)
+    })?;
+    let to: String = serde_json::from_value(to.clone())
+        .map_err(|_err| ErrorObjectOwned::borrowed(UNKNOWN_ADDRESS, "Could not parse `to` from rpc parameter", None))?;
+
+    Ok((from.to_lowercase(), to.to_lowercase()))
+}
+
+pub fn banned_address_call_result(data: Option<&'static RawValue>) -> CallResult {
+    Err(ErrorObjectOwned::borrowed(
+        ADDRESS_IS_BANNED,
+        "The address related to the rpc is banned",
+        data,
+    ))
+}
+
+#[async_trait]
+impl Middleware<CallRequest, CallResult> for WhitelistMiddleware {
+    async fn call(
+        &self,
+        request: CallRequest,
+        context: TypeRegistry,
+        next: NextFn<CallRequest, CallResult>,
+    ) -> CallResult {
+        async move {
+            match self.rpc_type {
+                RpcType::EthCall => {
+                    let (from, to) = extract_address_from_to(&request.params)?;
+                    if !self.satisfy(from, to) {
+                        return banned_address_call_result(None);
+                    }
+                }
+                RpcType::SendRaw => {
+                    // TODO:
+                }
+            }
+
+            next(request, context).await
+        }
+        .with_context(TRACER.context("whitelist"))
+        .await
+    }
+}

--- a/src/middlewares/methods/whitelist.rs
+++ b/src/middlewares/methods/whitelist.rs
@@ -50,7 +50,7 @@ impl WhitelistMiddleware {
         for address in &self.addresses {
             // if satisfy address from/to
             if address.satisfy(from, to) {
-                return true
+                return true;
             }
         }
 

--- a/src/middlewares/methods/whitelist.rs
+++ b/src/middlewares/methods/whitelist.rs
@@ -2,11 +2,12 @@ use async_trait::async_trait;
 use jsonrpsee::core::JsonValue;
 use jsonrpsee::types::ErrorObjectOwned;
 use opentelemetry::trace::FutureExt;
-use serde_json::value::RawValue;
 
 use alloy_consensus::{Transaction, TxEip4844Variant, TxEnvelope};
 use alloy_eips::eip2718::Decodable2718;
+use alloy_primitives::hex::decode;
 use alloy_primitives::{Address, TxKind};
+use serde::Serialize;
 
 use crate::extensions::whitelist::{WhiteAddress, Whitelist, ETH_CALL, SEND_RAW_TX, SEND_TX};
 use crate::utils::ToAddress;
@@ -26,6 +27,9 @@ pub const ILLEGAL_TX: i32 = -33002;
 
 /// The transaction signature is invalid.
 pub const ILLEGAL_TX_SIGNATURE: i32 = -33003;
+
+///The hex could not be decoded.
+pub const ILLEGAL_HEX: i32 = -33004;
 
 /// This whitelist middleware should be used at the top level whenever possible.
 pub struct WhitelistMiddleware {
@@ -74,12 +78,12 @@ impl MiddlewareBuilder<RpcMethod, CallRequest, CallResult> for WhitelistMiddlewa
                 addresses: whitelist.config.eth_call_whitelist.clone(),
             })),
             SEND_TX => Some(Box::new(Self {
-                rpc_type: RpcType::SendRawTX,
-                addresses: whitelist.config.raw_tx_whitelist.clone(),
-            })),
-            SEND_RAW_TX => Some(Box::new(Self {
                 rpc_type: RpcType::SendTX,
                 addresses: whitelist.config.tx_whitelist.clone(),
+            })),
+            SEND_RAW_TX => Some(Box::new(Self {
+                rpc_type: RpcType::SendRawTX,
+                addresses: whitelist.config.raw_tx_whitelist.clone(),
             })),
             _ => {
                 // other rpc types will skip this middleware.
@@ -91,13 +95,7 @@ impl MiddlewareBuilder<RpcMethod, CallRequest, CallResult> for WhitelistMiddlewa
 
 /// Extract the address from `eth_call`/`eth_sendTranslation` parameters and convert it into lowercase.
 pub fn extract_address_from_to(params: &[JsonValue]) -> Result<(Address, ToAddress), ErrorObjectOwned> {
-    let p1 = params.get(0).ok_or_else(|| {
-        ErrorObjectOwned::borrowed(
-            UNKNOWN_ADDRESS,
-            "Could not get the first param from rpc parameter",
-            None,
-        )
-    })?;
+    let p1 = params.get(0).ok_or_else(err_illegal_rpc_parameter)?;
 
     // `from` must exist.
     let from = p1.get("from").ok_or_else(|| {
@@ -110,8 +108,9 @@ pub fn extract_address_from_to(params: &[JsonValue]) -> Result<(Address, ToAddre
     // When not get, it means `Create`.
     let to = p1.get("to");
     let to = if let Some(to) = to {
-        serde_json::from_value(to.clone())
-            .map_err(|_err| ErrorObjectOwned::borrowed(UNKNOWN_ADDRESS, "Could not parse `to` from rpc parameter", None))?
+        serde_json::from_value(to.clone()).map_err(|_err| {
+            ErrorObjectOwned::borrowed(UNKNOWN_ADDRESS, "Could not parse `to` from rpc parameter", None)
+        })?
     } else {
         TxKind::Create
     };
@@ -137,31 +136,27 @@ impl Middleware<CallRequest, CallResult> for WhitelistMiddleware {
                 RpcType::EthCall | RpcType::SendTX => {
                     let (from, to) = extract_address_from_to(&request.params)?;
                     if !self.satisfy(&from, &to) {
-                        return banned_address_call_result(None);
+                        return Err(err_banned_address());
                     }
                 }
                 RpcType::SendRawTX => {
-                    let p1 = request.params.get(0).ok_or_else(|| {
-                        ErrorObjectOwned::borrowed(
-                            UNKNOWN_ADDRESS,
-                            "Could not get the first param from rpc parameter",
-                            None,
-                        )
-                    })?;
-                    let rlp_hex: String = serde_json::from_value(p1.clone()).map_err(|_err| {
-                        ErrorObjectOwned::borrowed(ILLEGAL_TX, "Could not get the first param from rpc parameter", None)
-                    })?;
-                    let tx: TxEnvelope = TxEnvelope::decode_2718(&mut rlp_hex.as_bytes())
-                        .map_err(|_err| ErrorObjectOwned::borrowed(ILLEGAL_TX, "Could not decode the raw txn", None))?;
+                    let p1 = request.params.get(0).ok_or_else(err_illegal_rpc_parameter)?;
+                    let rlp_hex: String =
+                        serde_json::from_value(p1.clone()).map_err(|_err| err_illegal_rpc_parameter())?;
+                    let rlp = decode(&mut rlp_hex.as_bytes()).map_err(|_err| err_failed_decode_hex(&rlp_hex))?;
+
+                    let tx: TxEnvelope =
+                        TxEnvelope::decode_2718(&mut rlp.as_slice()).map_err(|_err| err_failed_decode_txn(&rlp_hex))?;
+
                     let from = extract_signer_from_tx_envelop(&tx)?;
                     let to = extract_to_address_from_tx_envelop(&tx);
                     if !self.satisfy(&from, &to) {
-                        return banned_address_call_result(None);
+                        return Err(err_banned_address());
                     }
-                    // TODO:
                 }
             }
 
+            // pass the whitelist
             next(request, context).await
         }
         .with_context(TRACER.context("whitelist"))
@@ -203,10 +198,144 @@ fn extract_to_address_from_tx_envelop(tx: &TxEnvelope) -> ToAddress {
     to.into()
 }
 
-pub fn banned_address_call_result(data: Option<&'static RawValue>) -> CallResult {
-    Err(ErrorObjectOwned::borrowed(
-        ADDRESS_IS_BANNED,
-        "The address related to the rpc is banned",
-        data,
-    ))
+pub fn err_banned_address() -> ErrorObjectOwned {
+    ErrorObjectOwned::borrowed(ADDRESS_IS_BANNED, "The address related to the rpc is banned", None)
+}
+
+pub fn err_illegal_rpc_parameter() -> ErrorObjectOwned {
+    ErrorObjectOwned::borrowed(ILLEGAL_TX, "Failed to get the first param from rpc parameter", None)
+}
+
+pub fn err_failed_decode_txn<S: Serialize>(data: S) -> ErrorObjectOwned {
+    ErrorObjectOwned::owned(ILLEGAL_TX, "Failed to decode the txn", Some(data))
+}
+
+pub fn err_failed_decode_hex<S: Serialize>(data: S) -> ErrorObjectOwned {
+    ErrorObjectOwned::owned(ILLEGAL_HEX, "Failed to decode the hex", Some(data))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extensions::whitelist::WhitelistConfig;
+    use crate::extensions::ExtensionsConfig;
+    use alloy_primitives::{bytes, hex, Bytes};
+    use futures_util::FutureExt;
+    use serde_json::Value;
+
+    struct Case {
+        encoded_tx: Bytes,
+        expected_res: CallResult,
+    }
+
+    #[tokio::test]
+    #[allow(non_snake_case)]
+    async fn eth_sendRawTransaction_should_work() {
+        let rpc_method = r"
+method: eth_sendRawTransaction
+cache:
+    size: 0
+params:
+    - name: transaction
+      ty: Bytes
+";
+
+        let whitelist_config = r"
+    raw_tx_whitelist:
+      # allow 0x01 to call or create in raw tx.
+      - from: 0000000000000000000000000000000000000001
+";
+
+        let rpc_method: RpcMethod = serde_yaml::from_reader(&mut rpc_method.as_bytes()).unwrap();
+        let whitelist_config: WhitelistConfig = serde_yaml::from_reader(&mut whitelist_config.as_bytes()).unwrap();
+
+        let extensions = ExtensionsConfig {
+            whitelist: Some(whitelist_config),
+            ..Default::default()
+        }
+        .create_registry()
+        .await
+        .expect("Failed to create registry");
+
+        let middleware = WhitelistMiddleware::build(&rpc_method, &extensions).await.unwrap();
+
+        // See https://optimistic.etherscan.io/tx/0x664c3d2e1ac8b9db3038e7dbdb7402cb4105635e4b8b312f46e363239816d42b
+        let cases = vec![
+            Case {
+                encoded_tx: bytes!("f8aa8208da840393870082fde8940b2c639c533813f4aa9d7837caf62653d097ff8580b844a9059cbb00000000000000000000000026295137fbbd6fa569a844cdb20faea641577b2600000000000000000000000000000000000000000000000000000000000014d738a0fb193ba0e74178ab45cb7fbbce04d785b2be62c6bec9e7e23e7768a501a9c987a06ddef3b059fc47fd17acc83fa32ce6b0172f34e45a53c06bdaf239ec5b3fe5a6"),
+                expected_res: Err(err_banned_address()),
+            },
+        ];
+
+        for case in cases {
+            let rlp_hex = hex::encode_prefixed(case.encoded_tx);
+            let req = CallRequest::new("eth_sendRawTransaction", vec![Value::String(rlp_hex)]);
+            let expected_res = case.expected_res.clone();
+            let last = Box::new(move |_, _| async move { expected_res }.boxed());
+
+            let res = middleware.call(req, Default::default(), last);
+            let res = res.await;
+            assert_eq!(res, case.expected_res);
+        }
+    }
+
+    #[tokio::test]
+    #[allow(non_snake_case)]
+    async fn eth_sendRawTransaction_codec() {
+        let rpc_method = r"
+method: eth_sendRawTransaction
+cache:
+    size: 0
+params:
+    - name: transaction
+      ty: Bytes
+";
+
+        let whitelist_config = r"
+    raw_tx_whitelist:
+      # allow 0x1aB49795aE1570b8300E47493E090202b88f8F23 to call or create in raw tx.
+      - from: 0x1aB49795aE1570b8300E47493E090202b88f8F23
+";
+
+        let rpc_method: RpcMethod = serde_yaml::from_reader(&mut rpc_method.as_bytes()).unwrap();
+        let whitelist_config: WhitelistConfig = serde_yaml::from_reader(&mut whitelist_config.as_bytes()).unwrap();
+
+        let extensions = ExtensionsConfig {
+            whitelist: Some(whitelist_config),
+            ..Default::default()
+        }
+        .create_registry()
+        .await
+        .expect("Failed to create registry");
+
+        let middleware = WhitelistMiddleware::build(&rpc_method, &extensions).await.unwrap();
+
+        // See https://optimistic.etherscan.io/tx/0x664c3d2e1ac8b9db3038e7dbdb7402cb4105635e4b8b312f46e363239816d42b
+
+        // the first byte is changed
+        let failed_tx = bytes!("e8aa8208da840393870082fde8940b2c639c533813f4aa9d7837caf62653d097ff8580b844a9059cbb00000000000000000000000026295137fbbd6fa569a844cdb20faea641577b2600000000000000000000000000000000000000000000000000000000000014d738a0fb193ba0e74178ab45cb7fbbce04d785b2be62c6bec9e7e23e7768a501a9c987a06ddef3b059fc47fd17acc83fa32ce6b0172f34e45a53c06bdaf239ec5b3fe5a6");
+
+        let cases = vec![
+            Case {
+                encoded_tx: bytes!("f8aa8208da840393870082fde8940b2c639c533813f4aa9d7837caf62653d097ff8580b844a9059cbb00000000000000000000000026295137fbbd6fa569a844cdb20faea641577b2600000000000000000000000000000000000000000000000000000000000014d738a0fb193ba0e74178ab45cb7fbbce04d785b2be62c6bec9e7e23e7768a501a9c987a06ddef3b059fc47fd17acc83fa32ce6b0172f34e45a53c06bdaf239ec5b3fe5a6"),
+                expected_res: Ok(Value::String("0x664c3d2e1ac8b9db3038e7dbdb7402cb4105635e4b8b312f46e363239816d42b".to_string())),
+            },
+
+            Case {
+                expected_res: Err(err_failed_decode_txn(&failed_tx)),
+                encoded_tx: failed_tx,
+            }
+        ];
+
+        for case in cases {
+            let rlp_hex = hex::encode_prefixed(case.encoded_tx);
+            let req = CallRequest::new("eth_sendRawTransaction", vec![Value::String(rlp_hex)]);
+            let expected_res = case.expected_res.clone();
+            let last = Box::new(move |_, _| async move { expected_res }.boxed());
+
+            let res = middleware.call(req, Default::default(), last);
+            let res = res.await;
+            assert_eq!(res, case.expected_res);
+        }
+    }
 }

--- a/src/middlewares/subscriptions/merge_subscription.rs
+++ b/src/middlewares/subscriptions/merge_subscription.rs
@@ -185,7 +185,7 @@ impl MiddlewareBuilder<RpcSubscription, SubscriptionRequest, SubscriptionResult>
             .get::<MergeSubscription>()
             .expect("MergeSubscription extension not found");
 
-        Some(Box::new(MergeSubscriptionMiddleware::new(
+        Some(Box::new(Self::new(
             client,
             merge_strategy,
             merge_subscription.config.keep_alive_seconds,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,8 +1,10 @@
 mod cache;
 mod type_registry;
+mod to_address;
 
 pub use cache::*;
 pub use type_registry::*;
+pub use to_address::*;
 
 pub mod errors {
     use jsonrpsee::types::{

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,10 +1,10 @@
 mod cache;
-mod type_registry;
 mod to_address;
+mod type_registry;
 
 pub use cache::*;
-pub use type_registry::*;
 pub use to_address::*;
+pub use type_registry::*;
 
 pub mod errors {
     use jsonrpsee::types::{

--- a/src/utils/to_address.rs
+++ b/src/utils/to_address.rs
@@ -1,0 +1,103 @@
+use std::fmt::Display;
+use alloy_primitives::{Address, TxKind};
+use serde::{Deserialize, Deserializer};
+use crate::extensions::whitelist::WhiteAddress;
+
+/// The normalized `to` address:
+/// - Create: this call is contract deploy.
+/// - Call: this call is contract call.
+///
+/// Note: this type is similar to [`TxKind`] but different in serde parts.
+#[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
+#[serde(untagged)]
+pub enum ToAddress {
+    #[serde(deserialize_with = "deserialize_create")]
+    Create,
+    Call(Address),
+}
+
+/// Helper function to deserialize boxed blobs
+fn deserialize_create<'de, D>(deserializer: D) -> Result<(), D::Error>
+    where
+        D: Deserializer<'de>,
+{
+    let s = <String>::deserialize(deserializer)?;
+    if &s == "create" || &s == "Create" {
+        Ok(())
+    } else {
+        Err(serde::de::Error::custom("invalid `to` address"))
+    }
+}
+
+
+impl Display for crate::extensions::whitelist::ToAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Create => write!(f, "create"),
+            Self::Call(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+impl From<TxKind> for crate::extensions::whitelist::ToAddress {
+    fn from(tx: TxKind) -> Self {
+        Self::from(&tx)
+    }
+}
+
+impl From<&TxKind> for crate::extensions::whitelist::ToAddress {
+    fn from(tx: &TxKind) -> Self {
+        match tx {
+            TxKind::Call(addr) => Self::Call(*addr),
+            TxKind::Create => Self::Create,
+        }
+    }
+}
+
+impl From<&Address> for crate::extensions::whitelist::ToAddress {
+    fn from(to: &Address) -> Self {
+        Self::Call(*to)
+    }
+}
+
+impl From<Address> for crate::extensions::whitelist::ToAddress {
+    fn from(to: Address) -> Self {
+        Self::from(&to)
+    }
+}
+
+impl WhiteAddress {
+    /// Normalize the address.
+    pub fn normalize(&mut self) -> anyhow::Result<()> {
+        println!("white address: {:?}", self);
+        // if let Some(addr) = self.from.as_mut() {
+        //     let normalized = addr.to_lowercase();
+        //     if normalized.len() != 42 {
+        //         bail!("Illegal `from` address: {}", addr)
+        //     }
+        //     *addr = normalized
+        // }
+        // if let Some(addr) = self.to.as_mut() {
+        //     let normalized = addr.to_lowercase();
+        //     if normalized.len() != 42 || normalized != "create" {
+        //         bail!("Illegal `to` address: {}", addr)
+        //     }
+        //     *addr = normalized;
+        // }
+
+        Ok(())
+    }
+
+    /// Check if this is a white address.
+    pub fn satisfy(&self, from: &Address, to: &crate::extensions::whitelist::ToAddress) -> bool {
+        self.satisfy_from_address(from) && self.satisfy_to_address(to)
+    }
+
+    pub fn satisfy_from_address(&self, from: &Address) -> bool {
+        self.from == None || self.from.as_ref() == Some(from)
+    }
+
+    pub fn satisfy_to_address(&self, to: &crate::extensions::whitelist::ToAddress) -> bool {
+        self.to == None || self.to.as_ref() == Some(to)
+    }
+}


### PR DESCRIPTION
Whitelist config example:
```yaml
  whitelist:
    eth_call_whitelist:
      # allow 0x01 to call 0x02
      - from: 0000000000000000000000000000000000000001
        to: 0000000000000000000000000000000000000002
      # allow anyone to call 0x01
      - to: 0000000000000000000000000000000000000000
      # allow 0x02 to create contract
      - from: 0000000000000000000000000000000000000002
        to: create
    raw_tx_whitelist:
      # allow 0x01 to call or create in raw tx.
      - from: 0000000000000000000000000000000000000001
    tx_whitelist:
      # allow 0x01 to call or create in tx.
      - from: 0000000000000000000000000000000000000001
 ```

TODO: support blacklist