### PR TITLE
chore: update cache configs about eth fee APIs

### DIFF
--- a/rpc_configs/geth.yml
+++ b/rpc_configs/geth.yml
@@ -14,12 +14,15 @@ methods:
   - method: eth_gasPrice
     cache:
       size: 1
+      ttl_seconds: 12
   - method: eth_blobBaseFee
     cache:
       size: 1
+      ttl_seconds: 12
   - method: eth_maxPriorityFeePerGas
     cache:
       size: 1
+      ttl_seconds: 12
   - method: eth_feeHistory
     params:
       - name: blockCount

--- a/rpc_configs/standard.yml
+++ b/rpc_configs/standard.yml
@@ -14,18 +14,22 @@ methods:
   - method: eth_gasPrice
     cache:
       size: 1
+      ttl_seconds: 12
   - method: eth_blobBaseFee
     cache:
       size: 1
+      ttl_seconds: 12
   - method: eth_maxPriorityFeePerGas
     cache:
       size: 1
+      ttl_seconds: 12
   - method: eth_feeHistory
     params:
       - name: blockCount
         ty: Bytes
       - name: newestBlock
-        ty: Boolean
+        ty: BlockTag
+        inject: true
       - name: rewardPercentiles
         ty: Bytes
   # Eth namespace (sign)


### PR DESCRIPTION
`cache: ttl_seconds` configs of these RPCs need to be same as the block generation time